### PR TITLE
Fix fast multi-thread implementation

### DIFF
--- a/hanmat_mt.cpp
+++ b/hanmat_mt.cpp
@@ -533,7 +533,8 @@ NTL::GF2 solve_eq_for_lower_corner(struct experiment & experiment, int j, int i,
 
 bool chk_conds_for_solvability(struct experiment & experiment, int j, int i, int & effective_length)
 {
-  std::lock_guard<std::mutex> lg(asptl_mutex);
+  if (MULTI_THREAD_ON)
+	  asptl_mutex.lock();
   bool ret=false;
   
   for(int w1=2;w1<=max_len_side_grid;w1++)//w1 is the length of the side which is growing so that the main matrix has size (w1+1)x(w1+1)
@@ -553,6 +554,10 @@ bool chk_conds_for_solvability(struct experiment & experiment, int j, int i, int
 	  break;
 	}
     }
+
+  if (MULTI_THREAD_ON)
+	  asptl_mutex.unlock();
+
   return ret;
 }
 


### PR DESCRIPTION
To fix the fast multi-thread implementation the code went through the following changes:

1) A method d_c_s_mt has been created, therefore the solve_fast single thread use the original d_c_s method (with mutexes removed) and the solve_fast multi thread use d_c_s_mt
2) All write to the experiment.M and experiment.flags_M matrices are guarded in d_c_s_mt
3) The whole method chk_conds_for_solvability is lock when MULTI_THREAD is ON, this might be a point to optimize for multi-thread implementation
4) 2 different mutexes has been introduced:
    - determinant_mutex to protect read/write into experiment.M and experiment.flags_M
    - asptl_mutex to protect chk_conds_for_solvability function

Currently the fast multi-thread computation seems slower than the fast single-thread computation (at least for vectors <= 512 bit). One assumption is the cost of joining the thread in the multi-thread implementation but further investigation is required.